### PR TITLE
Add blog routes

### DIFF
--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -20,11 +20,19 @@ import { Route as LayoutLayout2Import } from './routes/_layout/_layout-2'
 import { Route as PostsPostIdDeepImport } from './routes/posts_.$postId.deep'
 import { Route as LayoutLayout2LayoutBImport } from './routes/_layout/_layout-2/layout-b'
 import { Route as LayoutLayout2LayoutAImport } from './routes/_layout/_layout-2/layout-a'
+import { Route as BlogImport } from './routes/blog'
+import { Route as BlogIndexImport } from './routes/blog.index'
+import { Route as BlogSlugImport } from './routes/blog.$slug'
 
 // Create/Update Routes
 
 const PostsRoute = PostsImport.update({
   path: '/posts',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const BlogRoute = BlogImport.update({
+  path: '/blog',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -43,9 +51,19 @@ const PostsIndexRoute = PostsIndexImport.update({
   getParentRoute: () => PostsRoute,
 } as any)
 
+const BlogIndexRoute = BlogIndexImport.update({
+  path: '/',
+  getParentRoute: () => BlogRoute,
+} as any)
+
 const PostsPostIdRoute = PostsPostIdImport.update({
   path: '/$postId',
   getParentRoute: () => PostsRoute,
+} as any)
+
+const BlogSlugRoute = BlogSlugImport.update({
+  path: '/$slug',
+  getParentRoute: () => BlogRoute,
 } as any)
 
 const LayoutLayout2Route = LayoutLayout2Import.update({
@@ -93,6 +111,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PostsImport
       parentRoute: typeof rootRoute
     }
+    '/blog': {
+      id: '/blog'
+      path: '/blog'
+      fullPath: '/blog'
+      preLoaderRoute: typeof BlogImport
+      parentRoute: typeof rootRoute
+    }
     '/_layout/_layout-2': {
       id: '/_layout/_layout-2'
       path: ''
@@ -107,12 +132,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PostsPostIdImport
       parentRoute: typeof PostsImport
     }
+    '/blog/$slug': {
+      id: '/blog/$slug'
+      path: '/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugImport
+      parentRoute: typeof BlogImport
+    }
     '/posts/': {
       id: '/posts/'
       path: '/'
       fullPath: '/posts/'
       preLoaderRoute: typeof PostsIndexImport
       parentRoute: typeof PostsImport
+    }
+    '/blog/': {
+      id: '/blog/'
+      path: '/'
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexImport
+      parentRoute: typeof BlogImport
     }
     '/_layout/_layout-2/layout-a': {
       id: '/_layout/_layout-2/layout-a'
@@ -149,6 +188,7 @@ export const routeTree = rootRoute.addChildren({
     }),
   }),
   PostsRoute: PostsRoute.addChildren({ PostsPostIdRoute, PostsIndexRoute }),
+  BlogRoute: BlogRoute.addChildren({ BlogSlugRoute, BlogIndexRoute }),
   PostsPostIdDeepRoute,
 })
 

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -104,6 +104,14 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             Posts
           </Link>
           <Link
+            to={'/blog'}
+            activeProps={{
+              className: 'font-bold',
+            }}
+          >
+            Blog
+          </Link>
+          <Link
             to="/layout-a"
             activeProps={{
               className: 'font-bold',

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -1,0 +1,29 @@
+import {
+  ErrorComponent,
+  ErrorComponentProps,
+  createFileRoute,
+} from '@tanstack/react-router'
+import { fetchBlogPost } from '../utils/blog'
+import { NotFound } from '~/components/NotFound'
+
+export const Route = createFileRoute('/blog/$slug')({
+  loader: async ({ params: { slug } }) => fetchBlogPost(slug),
+  errorComponent: BlogErrorComponent as any,
+  component: BlogPostComponent,
+  notFoundComponent: () => <NotFound>Blog post not found</NotFound>,
+})
+
+export function BlogErrorComponent({ error }: ErrorComponentProps) {
+  return <ErrorComponent error={error} />
+}
+
+function BlogPostComponent() {
+  const post = Route.useLoaderData()
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-xl font-bold underline">{post.title}</h4>
+      <div className="text-sm">{post.content}</div>
+    </div>
+  )
+}

--- a/app/routes/blog.index.tsx
+++ b/app/routes/blog.index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/blog/')({
+  component: BlogIndexComponent,
+})
+
+function BlogIndexComponent() {
+  return <div>Select a blog post.</div>
+}

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { createFileRoute, Link, Outlet } from '@tanstack/react-router'
+import { fetchBlogPosts } from '../utils/blog'
+
+export const Route = createFileRoute('/blog')({
+  loader: () => fetchBlogPosts(),
+  component: BlogComponent,
+})
+
+function BlogComponent() {
+  const posts = Route.useLoaderData()
+
+  return (
+    <div className="p-2 flex gap-2">
+      <ul className="list-disc pl-4">
+        {posts.map((post) => (
+          <li key={post.slug} className="whitespace-nowrap">
+            <Link
+              to="/blog/$slug"
+              params={{ slug: post.slug }}
+              className="block py-1 text-blue-800 hover:text-blue-600"
+              activeProps={{ className: 'text-black font-bold' }}
+            >
+              {post.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <hr />
+      <Outlet />
+    </div>
+  )
+}

--- a/app/utils/blog.tsx
+++ b/app/utils/blog.tsx
@@ -1,0 +1,35 @@
+import { notFound } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/start'
+
+export type BlogPost = {
+  slug: string
+  title: string
+  content: string
+}
+
+const blogPosts: BlogPost[] = [
+  {
+    slug: 'first-post',
+    title: 'First Post',
+    content: 'This is the first blog post.',
+  },
+  {
+    slug: 'second-post',
+    title: 'Second Post',
+    content: 'This is the second blog post.',
+  },
+]
+
+export const fetchBlogPosts = createServerFn('GET', async () => {
+  await new Promise((r) => setTimeout(r, 100))
+  return blogPosts
+})
+
+export const fetchBlogPost = createServerFn('GET', async (slug: string) => {
+  await new Promise((r) => setTimeout(r, 100))
+  const post = blogPosts.find((p) => p.slug === slug)
+  if (!post) {
+    throw notFound()
+  }
+  return post
+})


### PR DESCRIPTION
## Summary
- add `/blog` listing page
- add detail page under `/blog/$slug`
- expose `fetchBlogPosts` and `fetchBlogPost` utilities
- link to blog section from root navigation
- update route tree for new routes

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*